### PR TITLE
feat: Adiciona funcionalidade de adicionar transação

### DIFF
--- a/lib/app/core/enums/transaction_type.dart
+++ b/lib/app/core/enums/transaction_type.dart
@@ -1,0 +1,1 @@
+enum TransactionType { expense, income }

--- a/lib/app/ui/theme/app_color_extensions.dart
+++ b/lib/app/ui/theme/app_color_extensions.dart
@@ -20,9 +20,6 @@ class AppColorExtensions extends ThemeExtension<AppColorExtensions> {
     Color? onSuccess,
     Color? warning,
     Color? onWarning,
-    Color? gradientPrimary,
-    Color? gradientSecondary,
-    Color? gradientTertiary,
   }) {
     return AppColorExtensions(
       success: success ?? this.success,

--- a/lib/app/ui/theme/app_theme.dart
+++ b/lib/app/ui/theme/app_theme.dart
@@ -34,9 +34,7 @@ final lightTheme = ThemeData(
     ),
   ),
   textButtonTheme: TextButtonThemeData(
-    style: TextButton.styleFrom(
-      foregroundColor: AppColors.secondary,
-    ),
+    style: TextButton.styleFrom(foregroundColor: AppColors.secondary),
   ),
   inputDecorationTheme: const InputDecorationTheme(
     labelStyle: TextStyle(color: AppColors.lightTextPrimary),
@@ -47,11 +45,17 @@ final lightTheme = ThemeData(
     enabledBorder: UnderlineInputBorder(
       borderSide: BorderSide(color: AppColors.lightBorder),
     ),
+    errorBorder: OutlineInputBorder(
+      borderSide: BorderSide(color: AppColors.error, width: 1.0),
+    ),
+    focusedErrorBorder: OutlineInputBorder(
+      borderSide: BorderSide(color: AppColors.error, width: 2.0),
+    ),
   ),
   extensions: const <ThemeExtension<dynamic>>[
     AppColorExtensions(
-      onSuccess: AppColors.success,
-      success: AppColors.onSuccess,
+      onSuccess: AppColors.onSuccess,
+      success: AppColors.success,
       warning: AppColors.warning,
       onWarning: AppColors.onWarning,
     ),

--- a/lib/app/utils/app_validators.dart
+++ b/lib/app/utils/app_validators.dart
@@ -68,4 +68,14 @@ class AppValidators {
     }
     return null;
   }
+
+  static String? currency(String? value) {
+    if (value == null || value.isEmpty) {
+      return 'Por favor, insira um valor';
+    }
+    if (double.tryParse(value.replaceAll(',', '.')) == null) {
+      return 'Valor inválido';
+    }
+    return null;
+  }
 }

--- a/lib/app/utils/date_formatter.dart
+++ b/lib/app/utils/date_formatter.dart
@@ -3,6 +3,10 @@ import 'package:intl/intl.dart';
 class DateFormatter {
   static const String _locale = 'pt_BR';
 
+  static String formatSimpleDate(DateTime date) {
+    return DateFormat('dd/MM/yyyy', _locale).format(date);
+  }
+
   static String formatDayOfWeekWithDate() {
     final now = DateTime.now();
     final formattedDate = DateFormat('EEEE, dd/MM/yyyy', _locale).format(now);

--- a/lib/modules/home/controllers/add_transaction_controller.dart
+++ b/lib/modules/home/controllers/add_transaction_controller.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mobile_app/app/core/enums/transaction_type.dart';
+import 'package:mobile_app/app/services/snack_bar_service.dart';
+import 'package:mobile_app/app/utils/date_formatter.dart';
+
+class AddTransactionController extends GetxController {
+  // Utils
+  final SnackBarService snackBarService = Get.find();
+
+  // Form
+  final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+
+  // Controllers
+  final valueController = TextEditingController();
+  final descriptionController = TextEditingController();
+
+  // Form Fields
+  final selectedType = TransactionType.expense.obs;
+  final selectedCategory = RxnString();
+  final List<String> categories = [
+    '',
+    'Boleto',
+    'Cartão de débito',
+    'Cartão de crédito',
+    'Deposito bancário',
+    'Pix',
+    'Outro',
+  ];
+
+  // Conditionals
+  final RxBool isLoading = false.obs;
+
+  bool isFormValid() {
+    if (!formKey.currentState!.validate()) return true;
+
+    return false;
+  }
+
+  void setTransactionType(TransactionType type) {
+    selectedType.value = type;
+  }
+
+  void saveTransaction() {
+    if (isFormValid()) return;
+
+    final type = selectedType.value.toString().split('.').last;
+    final value =
+        double.tryParse(valueController.text.replaceAll(',', '.')) ?? 0.0;
+    final category = selectedCategory.value;
+    final description = descriptionController.text;
+    final date = DateTime.now();
+
+    debugPrint('--- Nova Transação Salva ---');
+    debugPrint('Tipo: $type');
+    debugPrint('Valor: $value');
+    debugPrint('Categoria: $category');
+    debugPrint('Descrição: $description');
+    debugPrint('Data: ${DateFormatter.formatSimpleDate(date)}');
+    debugPrint('-----------------------------');
+
+    Get.back();
+
+    snackBarService.showSuccess(
+      title: 'Sucesso!',
+      message: 'Sua transação foi salva.',
+    );
+
+    clearForm();
+  }
+
+  void clearForm() {
+    valueController.clear();
+    selectedCategory.value = '';
+    descriptionController.clear();
+    selectedType.value = TransactionType.expense;
+  }
+
+  @override
+  void onClose() {
+    valueController.dispose();
+
+    descriptionController.dispose();
+    super.onClose();
+  }
+}

--- a/lib/modules/home/home_binding.dart
+++ b/lib/modules/home/home_binding.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 import 'package:mobile_app/modules/dashboard/controllers/dashboard_controller.dart';
+import 'package:mobile_app/modules/home/controllers/add_transaction_controller.dart';
 import 'package:mobile_app/modules/home/controllers/home_controller.dart';
 
 class HomeBinding implements Bindings {
@@ -7,5 +8,6 @@ class HomeBinding implements Bindings {
   void dependencies() {
     Get.lazyPut<HomeController>(() => HomeController(), fenix: true);
     Get.lazyPut<DashboardController>(() => DashboardController(), fenix: true);
+    Get.lazyPut<AddTransactionController>(() => AddTransactionController(), fenix: true);
   }
 }

--- a/lib/modules/home/ui/home_screen.dart
+++ b/lib/modules/home/ui/home_screen.dart
@@ -2,14 +2,18 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/app/ui/constants/app_assets.dart';
 import 'package:mobile_app/modules/dashboard/ui/dashboard_screen.dart';
+import 'package:mobile_app/modules/home/controllers/add_transaction_controller.dart';
 import 'package:mobile_app/modules/home/controllers/home_controller.dart';
+import 'package:mobile_app/modules/home/widgets/add_transaction_sheet.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final controller = Get.find<HomeController>();
+    final homeController = Get.find<HomeController>();
+    final addTransactionController = Get.find<AddTransactionController>();
+
     final theme = Theme.of(context);
 
     final List<Widget> screens = [
@@ -20,10 +24,10 @@ class HomeScreen extends StatelessWidget {
     return Scaffold(
       backgroundColor: theme.scaffoldBackgroundColor,
       appBar: _buildAppBar(theme),
-      bottomNavigationBar: _buildNavigationBar(controller, theme),
-      floatingActionButton: _buildFloatingActionButton(theme),
+      bottomNavigationBar: _buildNavigationBar(homeController, theme),
+      floatingActionButton: _buildFloatingActionButton(theme, addTransactionController),
       floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
-      body: _buildBody(controller, screens),
+      body: _buildBody(homeController, screens),
     );
   }
 
@@ -83,12 +87,18 @@ class HomeScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildFloatingActionButton(ThemeData theme) {
+  Widget _buildFloatingActionButton(ThemeData theme, AddTransactionController controller) {
     return FloatingActionButton(
       tooltip: 'Adicionar extrato',
       backgroundColor: theme.colorScheme.secondary,
       elevation: 2.0,
-      onPressed: () {},
+      onPressed: () {
+        Get.bottomSheet(
+          AddTransactionSheet(controller: controller,),
+          backgroundColor: Theme.of(Get.context!).colorScheme.surface,
+          isScrollControlled: true,
+        );
+      },
       child: Icon(Icons.add, color: theme.colorScheme.onSecondary),
     );
   }

--- a/lib/modules/home/widgets/add_transaction_sheet.dart
+++ b/lib/modules/home/widgets/add_transaction_sheet.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mobile_app/app/core/enums/transaction_type.dart';
+import 'package:mobile_app/app/ui/widgets/custom_text_field.dart';
+import 'package:mobile_app/app/utils/app_validators.dart';
+import 'package:mobile_app/modules/home/controllers/add_transaction_controller.dart';
+
+class AddTransactionSheet extends StatelessWidget {
+  final AddTransactionController controller;
+
+  const AddTransactionSheet({super.key, required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Builder(
+      builder: (context) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 32.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('Nova Transação', style: theme.textTheme.headlineSmall),
+              const SizedBox(height: 16),
+              _buildTransactionForm(theme),
+              const SizedBox(height: 32),
+              ElevatedButton(
+                onPressed: controller.saveTransaction,
+                child: const Text('Salvar'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildTransactionForm(ThemeData theme) {
+    return Form(
+      key: controller.formKey,
+      child: Column(
+        spacing: 16,
+        children: [
+          Obx(
+            () => SegmentedButton<TransactionType>(
+              segments: const [
+                ButtonSegment(
+                  value: TransactionType.expense,
+                  label: Text('Saída'),
+                  icon: Icon(Icons.arrow_downward),
+                ),
+                ButtonSegment(
+                  value: TransactionType.income,
+                  label: Text('Entrada'),
+                  icon: Icon(Icons.arrow_upward),
+                ),
+              ],
+              selected: {controller.selectedType.value},
+              onSelectionChanged: (Set<TransactionType> newSelection) {
+                controller.setTransactionType(newSelection.first);
+              },
+            ),
+          ),
+          CustomTextField(
+            controller: controller.valueController,
+            labelText: 'Valor',
+            hintText: '0,00',
+            prefixIcon: Icons.attach_money,
+            keyboardType: TextInputType.numberWithOptions(decimal: true),
+            validator: AppValidators.currency,
+          ),
+          Obx(
+            () => DropdownButtonFormField<String>(
+              initialValue: controller.selectedCategory.value,
+              decoration: InputDecoration(
+                labelText: 'Categoria',
+                prefixIcon: const Icon(Icons.category_outlined),
+              ),
+              items: controller.categories.map((category) {
+                return DropdownMenuItem(value: category, child: Text(category));
+              }).toList(),
+              onChanged: (newValue) {
+                controller.selectedCategory.value = newValue;
+              },
+              validator: (value) => AppValidators.notEmpty(
+                value,
+                message: 'Por favor, selecione uma categoria.',
+              ),
+            ),
+          ),
+          CustomTextField(
+            controller: controller.descriptionController,
+            labelText: 'Descrição',
+            hintText: 'Super mercado, aluguel ...',
+            prefixIcon: Icons.description_outlined,
+            keyboardType: TextInputType.text,
+            validator: AppValidators.notEmpty,
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Este commit introduz a funcionalidade de adicionar novas transações (despesas e receitas) na tela inicial.

- **Novos Arquivos e Widgets:**
    - `AddTransactionSheet`: Bottom sheet para o formulário de nova transação.
    - `AddTransactionController`: Gerencia o estado e a lógica do formulário de nova transação.
    - `TransactionType`: Enum para definir o tipo de transação (despesa ou receita).
- **Modificações:**
    - **HomeScreen:** - Integra o `AddTransactionController`. - Adiciona um `FloatingActionButton` que abre o `AddTransactionSheet`.
    - **HomeBinding:**
        - Adiciona `AddTransactionController` às dependências.
    - **AppTheme:** - Ajusta cores de sucesso no `AppColorExtensions`. - Adiciona estilos de borda para erro em `InputDecorationTheme`.
    - **AppValidators:**
        - Adiciona validador `currency` para campos de valor monetário.
    - **DateFormatter:** - Adiciona método `formatSimpleDate` para formatar datas no formato `dd/MM/yyyy`.
- **Funcionalidades do Formulário:**
    - Seleção do tipo de transação (Entrada/Saída) usando `SegmentedButton`.
    - Campo para valor da transação com validação monetária.
    - Campo de seleção para categoria da transação.
    - Campo para descrição da transação.
    - Botão para salvar a transação, que exibe uma `SnackBar` de sucesso e limpa o formulário.