### PR TITLE
feat: Integra DatabaseService para criar documentos de usuário no Fir…

### DIFF
--- a/lib/app/bindings/app_binding.dart
+++ b/lib/app/bindings/app_binding.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 import 'package:mobile_app/app/services/auth_service.dart';
+import 'package:mobile_app/app/services/database_service.dart';
 import 'package:mobile_app/app/services/snack_bar_service.dart';
 import 'package:mobile_app/modules/auth/controllers/auth_controller.dart';
 
@@ -7,6 +8,7 @@ class AppBinding extends Bindings {
   @override
   void dependencies() {
     // Services
+    Get.put<DatabaseService>(DatabaseService());
     Get.put<AuthService>(AuthService());
     Get.put<SnackBarService>(SnackBarService());
 

--- a/lib/app/services/auth_service.dart
+++ b/lib/app/services/auth_service.dart
@@ -1,9 +1,11 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
+import 'package:mobile_app/app/services/database_service.dart';
 
 class AuthService extends GetxService {
   final FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
+  final DatabaseService _databaseService = Get.find();
 
   Future<User?> signIn({
     required String email,
@@ -36,10 +38,13 @@ class AuthService extends GetxService {
         password: password.trim(),
       );
 
-      if (userCredential.user != null) {
-        await userCredential.user!.updateDisplayName(name.trim());
-        await userCredential.user!.reload();
+      final newUser = userCredential.user;
+      if (newUser != null) {
+        await newUser.updateDisplayName(name.trim());
 
+        await _databaseService.createUserDocument(user: newUser, name: name.trim());
+
+        await newUser.reload();
         return _firebaseAuth.currentUser;
       }
       return null;

--- a/lib/app/services/database_service.dart
+++ b/lib/app/services/database_service.dart
@@ -1,0 +1,35 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:get/get.dart';
+
+class DatabaseService extends GetxService {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  /// Cria um documento para um novo usuário na coleção 'users'.
+  /// Usa o UID da autenticação como ID do documento.
+  Future<void> createUserDocument({
+    required User user,
+    required String name,
+  }) async {
+    try {
+      // Cria uma referência para o documento do usuário
+      final userDocRef = _firestore.collection('users').doc(user.uid);
+
+      // Define os dados do usuário
+      final userData = {
+        'uid': user.uid,
+        'name': name,
+        'email': user.email,
+        'createdAt': FieldValue.serverTimestamp(), // Usa o timestamp do servidor
+      };
+
+      // Envia os dados para o Firestore
+      await userDocRef.set(userData);
+
+    } catch (e) {
+      print("Erro ao criar documento do usuário: $e");
+      // Relança a exceção para que o AuthService possa tratá-la se necessário
+      rethrow;
+    }
+  }
+}


### PR DESCRIPTION
…estore

Este commit introduz o `DatabaseService`, responsável por interagir com o Cloud Firestore, e o integra ao fluxo de criação de conta para salvar informações adicionais do usuário.

- **`DatabaseService`:**
  - Novo serviço (`DatabaseService`) adicionado para gerenciar operações de banco de dados com o Firestore.
  - Implementa o método `createUserDocument` que cria um novo documento na coleção `users` com o `uid`, `name`, `email` do usuário e um `createdAt` timestamp.

- **`AuthService`:**
  - Injeta o `DatabaseService` no `AuthService`.
  - Ao criar um novo usuário (`signUp`), após a criação bem-sucedida no Firebase Auth e atualização do `displayName`, chama `_databaseService.createUserDocument` para persistir os dados do usuário no Firestore.

- **`AppBinding`:**
  - Adiciona `DatabaseService` aos bindings globais da aplicação, garantindo que ele esteja disponível para injeção de dependência onde for necessário.