### PR TITLE
feat: Implementa funcionalidade de salvar transação no Firestore

### DIFF
--- a/lib/app/data/models/transaction_model.dart
+++ b/lib/app/data/models/transaction_model.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:mobile_app/app/data/enums/transaction_type.dart';
 
 class TransactionModel {
@@ -16,4 +17,15 @@ class TransactionModel {
     required this.amount,
     required this.date,
   });
+
+  Map<String, dynamic> toMap(String userId) {
+    return {
+      'userId': userId,
+      'type': type.name,
+      'description': description,
+      'paymentMethod': paymentMethod,
+      'amount': amount,
+      'date': Timestamp.fromDate(date),
+    };
+  }
 }

--- a/lib/app/ui/widgets/custom_text_field.dart
+++ b/lib/app/ui/widgets/custom_text_field.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class CustomTextField extends StatelessWidget {
   final TextEditingController controller;
@@ -10,6 +11,7 @@ class CustomTextField extends StatelessWidget {
   final String? Function(String?)? validator;
   final TextInputType keyboardType;
   final bool readOnly;
+  final List<TextInputFormatter>? inputFormatters;
 
   const CustomTextField({
     super.key,
@@ -22,6 +24,7 @@ class CustomTextField extends StatelessWidget {
     this.validator,
     this.keyboardType = TextInputType.text,
     this.readOnly = false,
+    this.inputFormatters,
   });
 
   @override
@@ -39,6 +42,7 @@ class CustomTextField extends StatelessWidget {
         border: const OutlineInputBorder(),
       ),
       readOnly: readOnly,
+      inputFormatters: inputFormatters,
     );
   }
 }

--- a/lib/app/utils/app_validators.dart
+++ b/lib/app/utils/app_validators.dart
@@ -73,7 +73,7 @@ class AppValidators {
     if (value == null || value.isEmpty) {
       return 'Por favor, insira um valor';
     }
-    if (double.tryParse(value.replaceAll(',', '.')) == null) {
+    if (value == 'R\$ 0,00') {
       return 'Valor inválido';
     }
     return null;

--- a/lib/modules/auth/controllers/auth_controller.dart
+++ b/lib/modules/auth/controllers/auth_controller.dart
@@ -42,7 +42,7 @@ class AuthController extends GetxController {
         clearForm();
         Get.offAllNamed(Routes.HOME);
       }
-      ;
+
     } on FirebaseAuthException catch (e) {
       debugPrint(e.message);
 

--- a/lib/modules/home/home_binding.dart
+++ b/lib/modules/home/home_binding.dart
@@ -9,7 +9,7 @@ class HomeBinding implements Bindings {
   void dependencies() {
     Get.lazyPut<HomeController>(() => HomeController(), fenix: true);
     Get.lazyPut<DashboardController>(() => DashboardController(), fenix: true);
-    Get.lazyPut<AddTransactionController>(() => AddTransactionController(), fenix: true);
     Get.lazyPut<TransactionController>(() => TransactionController(), fenix: true);
+    Get.lazyPut<AddTransactionController>(() => AddTransactionController(), fenix: true);
   }
 }

--- a/lib/modules/home/ui/home_screen.dart
+++ b/lib/modules/home/ui/home_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:mobile_app/app/routes/app_pages.dart';
 import 'package:mobile_app/app/ui/constants/app_assets.dart';
 import 'package:mobile_app/modules/dashboard/ui/dashboard_screen.dart';
 import 'package:mobile_app/modules/home/controllers/add_transaction_controller.dart';
@@ -28,8 +27,8 @@ class HomeScreen extends StatelessWidget {
       appBar: _buildAppBar(homeController, theme),
       bottomNavigationBar: _buildNavigationBar(homeController, theme),
       floatingActionButton: _buildFloatingActionButton(
-        theme,
         addTransactionController,
+        theme,
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
       body: _buildBody(homeController, screens),
@@ -105,8 +104,8 @@ class HomeScreen extends StatelessWidget {
   }
 
   Widget _buildFloatingActionButton(
-    ThemeData theme,
     AddTransactionController controller,
+    ThemeData theme,
   ) {
     return FloatingActionButton(
       tooltip: 'Adicionar extrato',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -182,6 +182,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_masked_text2:
+    dependency: "direct main"
+    description:
+      name: flutter_masked_text2
+      sha256: "5ccf6f1f8b7b7a8025e3fbaea48bff0aa7e7e9512c723e26138a0b24f31ca4d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   # ui
   simple_gradient_text: ^1.3.0
   fl_chart: ^1.1.0
+  flutter_masked_text2: ^0.9.1
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Este commit introduz a lógica para salvar transações no Firestore e refatora o formulário de adição de transações.

- **Model de Transação:**
  - Adiciona o método `toMap` em `TransactionModel` para converter o modelo em um mapa compatível com o Firestore, incluindo `userId` e convertendo `date` para `Timestamp`.

- **Controller de Adição de Transação (`AddTransactionController`):**
  - Integra `DatabaseService` para persistir transações.
  - Utiliza `MoneyMaskedTextController` para formatação de valores monetários.
  - Diferencia métodos de pagamento para despesas (`_expenseMethods`) e receitas (`_incomeMethods`).
  - Adiciona `isLoading` para feedback visual durante o salvamento.
  - Implementa `saveTransaction` com tratamento de sucesso e erro, utilizando `SnackBarService`.
  - Constrói `TransactionModel` com `uuid.v4()` para IDs únicos.
  - Limpa o formulário (`clearForm`) e reseta os campos após salvar.
  - Atualiza a lógica de `setTransactionType` para resetar o método de pagamento selecionado.

- **Widget `AddTransactionSheet`:**
  - Refatora a estrutura do formulário, separando campos em métodos (`_buildTypeSelector`, `_buildValueField`, etc.).
  - Adiciona validação para o campo de valor, garantindo que seja maior que zero.
  - Atualiza o `DropdownButtonFormField` de método de pagamento para exibir opções baseadas no tipo de transação (despesa/receita) e mostrar `hintText` dinâmico.
  - Inclui `CircularProgressIndicator` no botão "Salvar" durante o carregamento.
  - Utiliza `ValueKey` no `DropdownButtonFormField` para garantir a reconstrução correta ao mudar o tipo de transação.

- **Serviço de Banco de Dados (`DatabaseService`):**
  - Adiciona o método `addTransaction` para salvar um `TransactionModel` na coleção 'transactions' do Firestore, associando-o ao `userId` do usuário autenticado.
  - Inclui tratamento de erro para usuário não autenticado.

- **Outras Modificações:**
  - Adiciona a dependência `flutter_masked_text2` em `pubspec.yaml` e `pubspec.lock`.
  - Ajusta a validação de moeda (`AppValidators.currency`) para considerar "R$ 0,00" como inválido.
  - Remove a anotação desnecessária ``;` em `AuthController`.
  - Reordena `Get.lazyPut` em `HomeBinding`.
  - Passa o `theme` como último parâmetro em `_buildFloatingActionButton` em `HomeScreen`.
  - Adiciona a propriedade `inputFormatters` em `CustomTextField` (embora não utilizada diretamente neste commit).