### PR TITLE
Refactor: Unifica formulário e implementa edição e exclusão de transa…

### DIFF
--- a/lib/app/data/models/transaction_model.dart
+++ b/lib/app/data/models/transaction_model.dart
@@ -28,4 +28,18 @@ class TransactionModel {
       'date': Timestamp.fromDate(date),
     };
   }
+
+  factory TransactionModel.fromMap(DocumentSnapshot doc) {
+    Map<String, dynamic> data = doc.data() as Map<String, dynamic>;
+    return TransactionModel(
+      id: doc.id,
+      type: (data['type'] as String) == 'income'
+          ? TransactionType.income
+          : TransactionType.expense,
+      description: data['description'] ?? '',
+      paymentMethod: data['paymentMethod'] ?? '',
+      amount: (data['amount'] as num).toDouble(),
+      date: (data['date'] as Timestamp).toDate(),
+    );
+  }
 }

--- a/lib/app/utils/date_formatter.dart
+++ b/lib/app/utils/date_formatter.dart
@@ -13,4 +13,23 @@ class DateFormatter {
 
     return formattedDate[0].toUpperCase() + formattedDate.substring(1);
   }
+
+  static String formatFriendlyDate(DateTime date) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final yesterday = DateTime(now.year, now.month, now.day - 1);
+    final tomorrow = DateTime(now.year, now.month, now.day + 1);
+
+    final dateToCompare = DateTime(date.year, date.month, date.day);
+
+    if (dateToCompare == today) {
+      return 'Hoje';
+    } else if (dateToCompare == yesterday) {
+      return 'Ontem';
+    } else if (dateToCompare == tomorrow) {
+      return 'Amanhã';
+    } else {
+      return formatSimpleDate(date);
+    }
+  }
 }

--- a/lib/modules/home/home_binding.dart
+++ b/lib/modules/home/home_binding.dart
@@ -1,6 +1,6 @@
 import 'package:get/get.dart';
 import 'package:mobile_app/modules/dashboard/controllers/dashboard_controller.dart';
-import 'package:mobile_app/modules/home/controllers/add_transaction_controller.dart';
+import 'package:mobile_app/modules/home/controllers/transaction_form_controller.dart';
 import 'package:mobile_app/modules/home/controllers/home_controller.dart';
 import 'package:mobile_app/modules/transaction/controllers/transaction_controller.dart';
 
@@ -10,6 +10,5 @@ class HomeBinding implements Bindings {
     Get.lazyPut<HomeController>(() => HomeController(), fenix: true);
     Get.lazyPut<DashboardController>(() => DashboardController(), fenix: true);
     Get.lazyPut<TransactionController>(() => TransactionController(), fenix: true);
-    Get.lazyPut<AddTransactionController>(() => AddTransactionController(), fenix: true);
   }
 }

--- a/lib/modules/home/ui/home_screen.dart
+++ b/lib/modules/home/ui/home_screen.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:mobile_app/app/ui/constants/app_assets.dart';
 import 'package:mobile_app/modules/dashboard/ui/dashboard_screen.dart';
-import 'package:mobile_app/modules/home/controllers/add_transaction_controller.dart';
+import 'package:mobile_app/modules/home/controllers/transaction_form_controller.dart';
 import 'package:mobile_app/modules/home/controllers/home_controller.dart';
-import 'package:mobile_app/modules/home/widgets/add_transaction_sheet.dart';
+import 'package:mobile_app/modules/home/widgets/transaction_form_sheet.dart';
 import 'package:mobile_app/modules/transaction/ui/transaction_screen.dart';
 
 class HomeScreen extends StatelessWidget {
@@ -13,7 +13,6 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final homeController = Get.find<HomeController>();
-    final addTransactionController = Get.find<AddTransactionController>();
 
     final theme = Theme.of(context);
 
@@ -26,10 +25,7 @@ class HomeScreen extends StatelessWidget {
       backgroundColor: theme.scaffoldBackgroundColor,
       appBar: _buildAppBar(homeController, theme),
       bottomNavigationBar: _buildNavigationBar(homeController, theme),
-      floatingActionButton: _buildFloatingActionButton(
-        addTransactionController,
-        theme,
-      ),
+      floatingActionButton: _buildFloatingActionButton(theme),
       floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
       body: _buildBody(homeController, screens),
     );
@@ -103,17 +99,14 @@ class HomeScreen extends StatelessWidget {
     );
   }
 
-  Widget _buildFloatingActionButton(
-    AddTransactionController controller,
-    ThemeData theme,
-  ) {
+  Widget _buildFloatingActionButton(ThemeData theme) {
     return FloatingActionButton(
       tooltip: 'Adicionar extrato',
       backgroundColor: theme.colorScheme.secondary,
       elevation: 2.0,
       onPressed: () {
         Get.bottomSheet(
-          AddTransactionSheet(controller: controller),
+          TransactionFormSheet(),
           backgroundColor: Theme.of(Get.context!).colorScheme.surface,
           isScrollControlled: true,
         );

--- a/lib/modules/home/widgets/transaction_form_sheet.dart
+++ b/lib/modules/home/widgets/transaction_form_sheet.dart
@@ -3,15 +3,14 @@ import 'package:get/get.dart';
 import 'package:mobile_app/app/data/enums/transaction_type.dart';
 import 'package:mobile_app/app/ui/widgets/custom_text_field.dart';
 import 'package:mobile_app/app/utils/app_validators.dart';
-import 'package:mobile_app/modules/home/controllers/add_transaction_controller.dart';
+import 'package:mobile_app/modules/home/controllers/transaction_form_controller.dart';
 
-class AddTransactionSheet extends StatelessWidget {
-  final AddTransactionController controller;
-
-  const AddTransactionSheet({super.key, required this.controller});
+class TransactionFormSheet extends GetView<TransactionFormController> {
+  const TransactionFormSheet({super.key});
 
   @override
   Widget build(BuildContext context) {
+    Get.put(TransactionFormController());
     final theme = Theme.of(context);
 
     return Padding(
@@ -22,7 +21,10 @@ class AddTransactionSheet extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text('Nova Transação', style: theme.textTheme.headlineSmall),
+            Text(
+              controller.isEditMode ? 'Editar Transação' : 'Nova Transação',
+              style: theme.textTheme.headlineSmall,
+            ),
             const SizedBox(height: 24),
             _buildTypeSelector(),
             const SizedBox(height: 16),

--- a/lib/modules/transaction/ui/transaction_screen.dart
+++ b/lib/modules/transaction/ui/transaction_screen.dart
@@ -4,62 +4,87 @@ import 'package:mobile_app/modules/transaction/controllers/transaction_controlle
 import 'package:mobile_app/modules/transaction/widgets/transaction_list_item.dart';
 import 'package:mobile_app/modules/transaction/widgets/transaction_options_sheet.dart';
 
-class TransactionScreen extends StatelessWidget {
+class TransactionScreen extends GetView<TransactionController> {
   const TransactionScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final controller = Get.find<TransactionController>();
-    final theme = Theme.of(context);
-
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 32.0),
       child: Obx(() {
         if (controller.transactions.isEmpty) {
-          return const Center(child: Text('Nenhuma transação encontrada.'));
+          return _buildEmptyState();
+        } else {
+          return _buildContent();
         }
-        return Card(
-          margin: EdgeInsets.zero,
-          color: theme.colorScheme.surface,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              spacing: 16,
-              children: [
-                Text('Lista de Transações', style: theme.textTheme.titleMedium),
-                const Divider(),
-                Expanded(
-                  child: ListView.separated(
-                    itemCount: controller.transactions.length,
-                    itemBuilder: (context, index) {
-                      final transaction = controller.transactions[index];
-                      return TransactionListItem(
-                        transaction: transaction,
-                        onTap: () {
-                          Get.bottomSheet(
-                            TransactionOptionsSheet(
-                              controller: controller,
-                              transactionId: transaction.id,
-                            ),
-                            backgroundColor: theme.colorScheme.surface,
-                          );
-                        },
-                      );
-                    },
-                    separatorBuilder: (context, index) =>
-                        const SizedBox(height: 8),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        );
       }),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return const Center(child: Text('Nenhuma transação encontrada.'));
+  }
+
+  Widget _buildContent() {
+    final theme = Theme.of(Get.context!);
+
+    return Card(
+      margin: EdgeInsets.zero,
+      color: theme.colorScheme.surface,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _buildListHeader(),
+            const SizedBox(height: 16),
+            _buildTransactionList(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildListHeader() {
+    final theme = Theme.of(Get.context!);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Lista de Transações', style: theme.textTheme.titleMedium),
+        const Divider(),
+      ],
+    );
+  }
+
+  Widget _buildTransactionList() {
+    return Expanded(
+      child: ListView.separated(
+        itemCount: controller.transactions.length,
+        itemBuilder: (context, index) {
+          final transaction = controller.transactions[index];
+          return TransactionListItem(
+            transaction: transaction,
+            onTap: () => _showOptionsSheet(transaction.id),
+          );
+        },
+        separatorBuilder: (context, index) => const SizedBox(height: 8),
+      ),
+    );
+  }
+
+  void _showOptionsSheet(String transactionId) {
+    final theme = Theme.of(Get.context!);
+
+    Get.bottomSheet(
+      TransactionOptionsSheet(
+        controller: controller,
+        transactionId: transactionId,
+      ),
+
+      backgroundColor: theme.colorScheme.surface,
     );
   }
 }

--- a/lib/modules/transaction/widgets/transaction_list_item.dart
+++ b/lib/modules/transaction/widgets/transaction_list_item.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:mobile_app/app/data/enums/transaction_type.dart';
 import 'package:mobile_app/app/data/models/transaction_model.dart';
+import 'package:mobile_app/app/utils/date_formatter.dart';
 
 class TransactionListItem extends StatelessWidget {
   final TransactionModel transaction;
@@ -59,6 +60,12 @@ class TransactionListItem extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          Text(
+            DateFormatter.formatFriendlyDate(transaction.date),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.8),
+            ),
+          ),
           Text(transaction.paymentMethod, style: theme.textTheme.titleMedium),
           Text(
             transaction.description,


### PR DESCRIPTION
…ções

Este commit refatora o formulário de transações, unificando a criação e edição em um único componente (`TransactionFormSheet` e `TransactionFormController`). Além disso, implementa a funcionalidade de edição e exclusão de transações, integrando com o `DatabaseService` para persistência no Firestore.

- **Refatoração do Formulário de Transação:**
    - Renomeia `AddTransactionSheet` para `TransactionFormSheet` e `AddTransactionController` para `TransactionFormController`.
    - `TransactionFormSheet` agora é um `GetView<TransactionFormController>` e obtém o controller via `Get.put()`.
    - O título do formulário é dinâmico ("Nova Transação" ou "Editar Transação") com base no modo de edição.
    - `TransactionFormController` agora recebe a transação a ser editada como argumento via `Get.arguments`.
    - Adiciona lógica para pré-preencher o formulário no modo de edição (`_prefillForm`).
    - Modifica `submitForm()` para diferenciar entre criar uma nova transação (`_databaseService.addTransaction`) e atualizar uma existente (`_databaseService.updateTransaction`).
    - Ajusta as mensagens de sucesso para refletir se a transação foi criada ou atualizada.
    - Remove o `AddTransactionController` dos bindings do `HomeBinding`.

- **Integração com Firestore e Edição/Exclusão:**
    - `TransactionModel`: Adiciona o factory constructor `fromMap` para desserializar dados do Firestore.
    - `DatabaseService`:
        - Adiciona `getTransactionsStream()` para ouvir em tempo real as transações do usuário logado, ordenadas por data.
        - Adiciona `updateTransaction()` para atualizar uma transação existente no Firestore. - Adiciona `deleteTransaction()` para excluir uma transação do Firestore.
    - `TransactionController`: - Substitui o carregamento de transações de exemplo por uma escuta ao `getTransactionsStream()` do `DatabaseService`. - Implementa `editTransaction()`:
            - Busca a transação pelo ID. - Abre o `TransactionFormSheet` passando a transação como argumento para edição.
        - Implementa `deleteTransaction()`: - Exibe um diálogo de confirmação (`AppDialogs.showConfirmationDialog`). - Em caso de confirmação, chama `_databaseService.deleteTransaction()`. - Exibe mensagens de sucesso ou erro.
    - `TransactionScreen`: - Converte para `GetView<TransactionController>`. - Refatora a construção da UI para métodos privados (`_buildEmptyState`, `_buildContent`, `_buildListHeader`, `_buildTransactionList`). - Ao tocar em um item da lista, chama `_showOptionsSheet()` que, por sua vez, exibe `TransactionOptionsSheet` para permitir edição ou exclusão.
    - `HomeScreen`:
        - Remove a injeção do `AddTransactionController` no `_buildFloatingActionButton`.
        - O `FloatingActionButton` agora abre diretamente o `TransactionFormSheet`.

- **Melhorias na UI e Utilitários:**
    - `DateFormatter`: Adiciona `formatFriendlyDate()` para exibir datas como "Hoje", "Ontem" ou no formato simplificado.
    - `TransactionListItem`: Utiliza `DateFormatter.formatFriendlyDate()` para exibir a data da transação de forma mais amigável.
    - `TransactionFormController`: Limpa os controladores de texto (`valueController`, `descriptionController`) no `onClose`.
    - `TransactionFormController`: Adiciona a propriedade `isEditMode` para facilitar a verificação do modo do formulário.