### PR TITLE
feat: Implementa lógica de saldo e atualização de transações no dashb…

### DIFF
--- a/lib/modules/dashboard/controllers/dashboard_controller.dart
+++ b/lib/modules/dashboard/controllers/dashboard_controller.dart
@@ -1,13 +1,31 @@
+import 'dart:async';
+
 import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+import 'package:mobile_app/app/data/enums/transaction_type.dart';
+import 'package:mobile_app/app/services/database_service.dart';
 import 'package:mobile_app/app/utils/date_formatter.dart';
+import 'package:mobile_app/modules/transaction/controllers/transaction_controller.dart';
 
 class DashboardController extends GetxController {
-  // Conditionals
+  // --- DEPENDÊNCIAS ---
+  final DatabaseService _databaseService = Get.find();
+  final TransactionController _transactionController = Get.find();
+  final NumberFormat currencyFormatter = NumberFormat.currency(
+    locale: 'pt_BR',
+    symbol: 'R\$',
+  );
+
+  // --- ESTADO REATIVO ---
+  final RxDouble totalBalance = 0.0.obs;
+  final RxDouble monthlyIncome = 0.0.obs;
+  final RxDouble monthlyExpenses = 0.0.obs;
   final RxBool isBalanceVisible = false.obs;
+  final Rx<DateTime> selectedMonth = DateTime.now().obs;
 
-  // Others
+  // --- PROPRIEDADES INTERNAS ---
   final String now = DateFormatter.formatDayOfWeekWithDate();
-
+  late StreamSubscription _userSubscription;
   final Map<String, double> sampleSpending = {
     'PIX': 1200.0,
     'Cartão de Crédito': 800.0,
@@ -16,7 +34,64 @@ class DashboardController extends GetxController {
     'Vale Alimentação': 40.0,
   };
 
-  void toggleBalanceVisibility() {
-    isBalanceVisible.toggle();
+  // --- GETTERS ---
+  String get formattedTotalBalance =>
+      currencyFormatter.format(totalBalance.value);
+
+  String get formattedMonthlyIncome =>
+      currencyFormatter.format(monthlyIncome.value);
+
+  String get formattedMonthlyExpenses =>
+      currencyFormatter.format(monthlyExpenses.value);
+
+  @override
+  void onInit() {
+    super.onInit();
+
+    _listenToUserStream();
+    _setupSummaryListeners();
   }
+
+  @override
+  void onClose() {
+    _userSubscription.cancel();
+
+    super.onClose();
+  }
+
+  void _setupSummaryListeners() {
+    ever(_transactionController.transactions, (_) => _calculateSummaries());
+    ever(selectedMonth, (_) => _calculateSummaries());
+  }
+
+  void _listenToUserStream() {
+    _userSubscription = _databaseService.getUserStream().listen((userDoc) {
+      if (userDoc.exists) {
+        final data = userDoc.data() as Map<String, dynamic>?;
+        totalBalance.value = data?['balance']?.toDouble() ?? 0.0;
+      }
+    });
+  }
+
+  void _calculateSummaries() {
+    double income = 0.0;
+    double expenses = 0.0;
+
+    final monthlyTransactions = _transactionController.transactions.where((t) {
+      return t.date.year == selectedMonth.value.year &&
+          t.date.month == selectedMonth.value.month;
+    });
+
+    for (var t in monthlyTransactions) {
+      if (t.type == TransactionType.income) {
+        income += t.amount;
+      } else {
+        expenses += t.amount;
+      }
+    }
+    monthlyIncome.value = income;
+    monthlyExpenses.value = expenses;
+  }
+
+  void toggleBalanceVisibility() => isBalanceVisible.toggle();
 }

--- a/lib/modules/dashboard/ui/dashboard_screen.dart
+++ b/lib/modules/dashboard/ui/dashboard_screen.dart
@@ -28,24 +28,27 @@ class DashboardScreen extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 spacing: 16,
                 children: [
+                  // TODO: recuperar dados do firestore
                   HeaderWidget(
                     name: 'Carlos Callejas',
                     message: 'Bem vindo de volta!',
                     date: controller.now,
                     url: 'https://randomuser.me/api/portraits/men/76.jpg',
                   ),
-                  CreditCardWidget(
+                  // TODO: recuperar dados do cartão do firestore
+                  Obx(() => CreditCardWidget(
                     controller: controller,
                     number: '4321',
                     validity: '12/26',
-                    balance: '12.555,00',
+                    balance: controller.formattedTotalBalance,
                     accountType: 'Conta Corrente',
-                  ),
-                  const BalanceSummaryWidget(
-                    total: 7000.00,
-                    income: 5000.00,
-                    expenses: 2000.00,
-                  ),
+                  )),
+                  Obx(() => BalanceSummaryWidget(
+                    total: controller.totalBalance.value,
+                    income: controller.monthlyIncome.value,
+                    expenses: controller.monthlyExpenses.value,
+                  )),
+                  // TODO: recuperar dados do firestore
                   SpendingSummaryWidget(
                     spendingData: controller.sampleSpending,
                   ),

--- a/lib/modules/dashboard/widgets/credit_card_widget.dart
+++ b/lib/modules/dashboard/widgets/credit_card_widget.dart
@@ -94,7 +94,7 @@ class CreditCardWidget extends StatelessWidget {
                   ),
                   Text(
                     controller.isBalanceVisible.value
-                        ? 'R\$ $balance'
+                        ? balance
                         : 'R\$ ******',
                     style: theme.textTheme.bodyLarge!.copyWith(
                       color: foreground,

--- a/lib/modules/home/controllers/transaction_form_controller.dart
+++ b/lib/modules/home/controllers/transaction_form_controller.dart
@@ -104,7 +104,10 @@ class TransactionFormController extends GetxController {
           date: editingTransaction!.date,
         );
 
-        await _databaseService.updateTransaction(updatedTransaction);
+        await _databaseService.updateTransaction(
+            editingTransaction!,
+            updatedTransaction
+        );
 
         _handleSuccess(isUpdate: true);
       } else {

--- a/lib/modules/transaction/controllers/transaction_controller.dart
+++ b/lib/modules/transaction/controllers/transaction_controller.dart
@@ -40,36 +40,25 @@ class TransactionController extends GetxController {
     });
   }
 
-  void editTransaction(String id) {
-    final TransactionModel? transactionToEdit = transactions.firstWhereOrNull(
-      (t) => t.id == id,
-    );
-
-    if (transactionToEdit == null) {
-      snackBarService.showError(
-        title: 'Erro',
-        message: 'Transação não encontrada.',
-      );
-
-      return;
-    }
-
+  void editTransaction(TransactionModel transactionToEdit) {
     Get.bottomSheet(
-      TransactionFormSheet(),
+      const TransactionFormSheet(),
       backgroundColor: Get.theme.colorScheme.surface,
       isScrollControlled: true,
-      settings: RouteSettings(arguments: transactionToEdit),
+      settings: RouteSettings(
+        arguments: transactionToEdit,
+      ),
     );
   }
 
-  void deleteTransaction(String id) {
+  void deleteTransaction(TransactionModel transaction) {
     AppDialogs.showConfirmationDialog(
       title: 'Confirmar Exclusão',
       message:
-          'Você tem certeza que deseja deletar esta transação? Esta ação não pode ser desfeita.',
+      'Você tem certeza que deseja deletar esta transação? Esta ação não pode ser desfeita.',
       onConfirm: () async {
         try {
-          await _databaseService.deleteTransaction(id);
+          await _databaseService.deleteTransaction(transaction);
 
           snackBarService.showSuccess(
             title: 'Sucesso!',

--- a/lib/modules/transaction/ui/transaction_screen.dart
+++ b/lib/modules/transaction/ui/transaction_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:mobile_app/app/data/models/transaction_model.dart';
 import 'package:mobile_app/modules/transaction/controllers/transaction_controller.dart';
 import 'package:mobile_app/modules/transaction/widgets/transaction_list_item.dart';
 import 'package:mobile_app/modules/transaction/widgets/transaction_options_sheet.dart';
@@ -67,7 +68,7 @@ class TransactionScreen extends GetView<TransactionController> {
           final transaction = controller.transactions[index];
           return TransactionListItem(
             transaction: transaction,
-            onTap: () => _showOptionsSheet(transaction.id),
+            onTap: () => _showOptionsSheet(transaction),
           );
         },
         separatorBuilder: (context, index) => const SizedBox(height: 8),
@@ -75,13 +76,13 @@ class TransactionScreen extends GetView<TransactionController> {
     );
   }
 
-  void _showOptionsSheet(String transactionId) {
+  void _showOptionsSheet(TransactionModel transaction) {
     final theme = Theme.of(Get.context!);
 
     Get.bottomSheet(
       TransactionOptionsSheet(
         controller: controller,
-        transactionId: transactionId,
+        transaction: transaction,
       ),
 
       backgroundColor: theme.colorScheme.surface,

--- a/lib/modules/transaction/widgets/transaction_options_sheet.dart
+++ b/lib/modules/transaction/widgets/transaction_options_sheet.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:mobile_app/app/data/models/transaction_model.dart';
 import 'package:mobile_app/modules/transaction/controllers/transaction_controller.dart';
 
 class TransactionOptionsSheet extends StatelessWidget {
   final TransactionController controller;
-  final String transactionId;
+  final TransactionModel transaction;
 
   const TransactionOptionsSheet({
     super.key,
     required this.controller,
-    required this.transactionId,
+    required this.transaction,
   });
 
   @override
@@ -27,7 +28,7 @@ class TransactionOptionsSheet extends StatelessWidget {
             title: Text('Editar Transação'),
             onTap: () {
               Get.back();
-              controller.editTransaction(transactionId);
+              controller.editTransaction(transaction);
             },
           ),
           ListTile(
@@ -38,7 +39,7 @@ class TransactionOptionsSheet extends StatelessWidget {
             title: Text('Deletar Transação'),
             onTap: () {
               Get.back();
-              controller.deleteTransaction(transactionId);
+              controller.deleteTransaction(transaction);
             },
           ),
         ],


### PR DESCRIPTION
…oard

Este commit introduz a funcionalidade de cálculo e exibição de saldo total, receitas e despesas mensais no dashboard, além de refatorar a lógica de edição e exclusão de transações para utilizar o objeto `TransactionModel` e atualizar o saldo do usuário de forma transacional.

- **Dashboard:**
    - `DashboardController`: - Adiciona `totalBalance`, `monthlyIncome`, `monthlyExpenses` e `selectedMonth` como estado reativo. - Implementa `_listenToUserStream` para observar e atualizar o `totalBalance` a partir do Firestore. - Implementa `_calculateSummaries` para calcular receitas e despesas mensais com base nas transações e no mês selecionado. - Utiliza `NumberFormat` para formatar os valores monetários. - Configura listeners para recalcular os resumos quando as transações ou o mês selecionado mudam.
    - `DashboardScreen`:
        - Atualiza `CreditCardWidget` e `BalanceSummaryWidget` para exibir os dados formatados do `DashboardController` dentro de `Obx`.
    - `CreditCardWidget`: - Exibe o saldo formatado do `DashboardController`.

- **Transações:**
    - `DatabaseService`: - Modifica `createUserDocument` para inicializar o campo `balance` do usuário com `0.0`. - Adiciona `getUserStream` para obter um stream do documento do usuário. - Refatora `addTransaction`, `updateTransaction` e `deleteTransaction` para: - Executar as operações dentro de uma transação do Firestore (`runTransaction`). - Atualizar o campo `balance` do usuário de acordo com o tipo e valor da transação. - `updateTransaction` agora recebe o `oldTransaction` e `newTransaction` para calcular corretamente a mudança no saldo. - `deleteTransaction` agora recebe o `TransactionModel` para reverter o impacto no saldo.
    - `TransactionController`:
        - Modifica `editTransaction` e `deleteTransaction` para receberem o objeto `TransactionModel` em vez do `id`.
    - `TransactionFormController`: - Ajusta a chamada a `_databaseService.updateTransaction` para passar o `editingTransaction` (transação antiga) e `updatedTransaction` (transação nova).
    - `TransactionOptionsSheet`:
        - Passa o objeto `TransactionModel` completo para os métodos `editTransaction` e `deleteTransaction` do controller.
    - `TransactionScreen`: - Passa o objeto `TransactionModel` completo ao exibir o `TransactionOptionsSheet`.