### PR TITLE
feat: Implementa seletor de mês e exibe resultado mensal no dashboard

### DIFF
--- a/lib/modules/dashboard/controllers/dashboard_controller.dart
+++ b/lib/modules/dashboard/controllers/dashboard_controller.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:intl/intl.dart';
 import 'package:mobile_app/app/data/enums/transaction_type.dart';
 import 'package:mobile_app/app/services/database_service.dart';
 import 'package:mobile_app/app/utils/date_formatter.dart';
 import 'package:mobile_app/modules/transaction/controllers/transaction_controller.dart';
+import 'package:month_picker_dialog/month_picker_dialog.dart';
 
 class DashboardController extends GetxController {
   // --- DEPENDÊNCIAS ---
@@ -35,14 +37,19 @@ class DashboardController extends GetxController {
   };
 
   // --- GETTERS ---
-  String get formattedTotalBalance =>
-      currencyFormatter.format(totalBalance.value);
-
-  String get formattedMonthlyIncome =>
-      currencyFormatter.format(monthlyIncome.value);
-
-  String get formattedMonthlyExpenses =>
-      currencyFormatter.format(monthlyExpenses.value);
+  String get formattedTotalBalance => currencyFormatter.format(totalBalance.value);
+  String get formattedMonthlyIncome => currencyFormatter.format(monthlyIncome.value);
+  String get formattedMonthlyExpenses => currencyFormatter.format(monthlyExpenses.value);
+  // GETTER PARA O RESULTADO DO MÊS
+  String get formattedMonthlyNetResult =>
+      currencyFormatter.format(monthlyIncome.value - monthlyExpenses.value);
+  // GETTER PARA EXIBIR O MÊS/ANO SELECIONADO
+  String get formattedSelectedMonth {
+    // 'MMMM' para o nome completo do mês (ex: "Setembro")
+    String formatted = DateFormat('MMMM yyyy', 'pt_BR').format(selectedMonth.value);
+    // Capitaliza a primeira letra
+    return formatted[0].toUpperCase() + formatted.substring(1);
+  }
 
   @override
   void onInit() {
@@ -91,6 +98,37 @@ class DashboardController extends GetxController {
     }
     monthlyIncome.value = income;
     monthlyExpenses.value = expenses;
+  }
+
+  void goToPreviousMonth() {
+    selectedMonth.value = DateTime(
+      selectedMonth.value.year,
+      selectedMonth.value.month - 1,
+    );
+  }
+
+  void goToNextMonth() {
+    selectedMonth.value = DateTime(
+      selectedMonth.value.year,
+      selectedMonth.value.month + 1,
+    );
+  }
+
+  Future<void> selectMonth(BuildContext context) async {
+    final pickedMonth = await showMonthPicker(
+      context: context,
+      initialDate: selectedMonth.value,
+    );
+
+    if (pickedMonth != null && pickedMonth != selectedMonth.value) {
+      selectedMonth.value = pickedMonth;
+    }
+  }
+
+  double calculatePercentage(double value, double otherValue) {
+    final maxVal = (value + otherValue);
+    if (maxVal == 0) return 0.0;
+    return value / maxVal;
   }
 
   void toggleBalanceVisibility() => isBalanceVisible.toggle();

--- a/lib/modules/dashboard/ui/dashboard_screen.dart
+++ b/lib/modules/dashboard/ui/dashboard_screen.dart
@@ -43,11 +43,7 @@ class DashboardScreen extends StatelessWidget {
                     balance: controller.formattedTotalBalance,
                     accountType: 'Conta Corrente',
                   )),
-                  Obx(() => BalanceSummaryWidget(
-                    total: controller.totalBalance.value,
-                    income: controller.monthlyIncome.value,
-                    expenses: controller.monthlyExpenses.value,
-                  )),
+                  BalanceSummaryWidget(controller: controller,),
                   // TODO: recuperar dados do firestore
                   SpendingSummaryWidget(
                     spendingData: controller.sampleSpending,

--- a/lib/modules/dashboard/widgets/balance_summary_widget.dart
+++ b/lib/modules/dashboard/widgets/balance_summary_widget.dart
@@ -1,18 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:intl/intl.dart';
+import 'package:mobile_app/modules/dashboard/controllers/dashboard_controller.dart';
 
 class BalanceSummaryWidget extends StatelessWidget {
-  final double total;
-  final double income;
-  final double expenses;
+  final DashboardController controller;
 
-  const BalanceSummaryWidget({
-    super.key,
-    required this.total,
-    required this.income,
-    required this.expenses,
-  });
+  const BalanceSummaryWidget({super.key, required this.controller});
 
   @override
   Widget build(BuildContext context) {
@@ -32,35 +26,78 @@ class BalanceSummaryWidget extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Text('Valor Total em Conta', style: theme.textTheme.titleMedium),
+            _buildMonthSelector(context),
+            const SizedBox(height: 16),
+            Text('Resultado do Mês', style: theme.textTheme.titleMedium),
             const SizedBox(height: 8),
-            Text(
-              currencyFormatter.format(total),
-              style: theme.textTheme.headlineMedium?.copyWith(
-                fontWeight: FontWeight.bold,
+            Obx(
+              () => Text(
+                controller.formattedMonthlyNetResult,
+                style: theme.textTheme.headlineMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
             const SizedBox(height: 16),
             const Divider(),
             const SizedBox(height: 16),
-            _financialProgressBar(
-              label: 'Entrada',
-              value: income,
-              percentage: total > 0 ? income / total : 0,
-              color: Colors.green,
-              currencyFormatter: currencyFormatter,
+            Obx(
+              () => _financialProgressBar(
+                label: 'Entrada',
+                value: controller.monthlyIncome.value,
+                percentage: controller.calculatePercentage(
+                  controller.monthlyIncome.value,
+                  controller.monthlyExpenses.value,
+                ),
+                color: Colors.green,
+                currencyFormatter: currencyFormatter,
+              ),
             ),
             const SizedBox(height: 24),
-            _financialProgressBar(
-              label: 'Saída',
-              value: expenses,
-              percentage: total > 0 ? expenses / total : 0,
-              color: theme.colorScheme.error,
-              currencyFormatter: currencyFormatter,
+            Obx(
+              () => _financialProgressBar(
+                label: 'Saída',
+                value: controller.monthlyExpenses.value,
+                percentage: controller.calculatePercentage(
+                  controller.monthlyExpenses.value,
+                  controller.monthlyIncome.value,
+                ),
+                color: theme.colorScheme.error,
+                currencyFormatter: currencyFormatter,
+              ),
             ),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildMonthSelector(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        IconButton(
+          icon: const Icon(Icons.chevron_left),
+          onPressed: controller.goToPreviousMonth,
+        ),
+        InkWell(
+          onTap: () => controller.selectMonth(context),
+          borderRadius: BorderRadius.circular(8),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+            child: Obx(
+              () => Text(
+                controller.formattedSelectedMonth,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ),
+          ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.chevron_right),
+          onPressed: controller.goToNextMonth,
+        ),
+      ],
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -288,6 +288,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  month_picker_dialog:
+    dependency: "direct main"
+    description:
+      name: month_picker_dialog
+      sha256: "8196c59bbd3339ea57de2c372ca51a8cfdbb242d6e45100925b9e1982ba4617d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -304,6 +320,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5+1"
   simple_gradient_text:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   simple_gradient_text: ^1.3.0
   fl_chart: ^1.1.0
   flutter_masked_text2: ^0.9.1
+  month_picker_dialog: ^6.5.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Este commit introduz a funcionalidade de seleção de mês no dashboard, permitindo ao usuário visualizar o balanço financeiro de diferentes períodos. Adicionalmente, o widget de resumo de balanço agora exibe o resultado líquido do mês (entradas - saídas).

- **DashboardController:**
  - Adiciona a variável `selectedMonth` (Rx<DateTime>) para controlar o mês exibido.
  - Implementa os métodos `goToPreviousMonth()`, `goToNextMonth()` e `selectMonth()` para navegação e seleção de mês utilizando o `month_picker_dialog`.
  - Adiciona o getter `formattedSelectedMonth` para exibir o mês e ano formatados.
  - Adiciona o getter `formattedMonthlyNetResult` para calcular e formatar o resultado líquido do mês.
  - Inclui o método `calculatePercentage()` para calcular corretamente a proporção de entradas e saídas.

- **BalanceSummaryWidget:**
  - Refatora o widget para receber o `DashboardController` como parâmetro, em vez de valores individuais.
  - Adiciona um seletor de mês (`_buildMonthSelector`) que permite ao usuário navegar entre os meses e abrir um seletor de mês/ano.
  - Exibe o "Resultado do Mês" (`controller.formattedMonthlyNetResult`) em destaque.
  - Atualiza as barras de progresso de "Entrada" e "Saída" para refletir os valores e percentuais do mês selecionado, utilizando os dados do `DashboardController`.

- **Dependências:**
  - Adiciona a dependência `month_picker_dialog: ^6.5.0` ao `pubspec.yaml` e `pubspec.lock` para a funcionalidade de seleção de mês.
  - Adiciona as dependências transitivas `nested` e `provider` ao `pubspec.lock`.

- **DashboardScreen:**
  - Atualiza a instanciação do `BalanceSummaryWidget` para passar o `DashboardController`.