### PR TITLE
feat: Adiciona exibição de gastos e receitas por categoria

### DIFF
--- a/lib/modules/dashboard/ui/dashboard_screen.dart
+++ b/lib/modules/dashboard/ui/dashboard_screen.dart
@@ -44,10 +44,26 @@ class DashboardScreen extends StatelessWidget {
                     accountType: 'Conta Corrente',
                   )),
                   BalanceSummaryWidget(controller: controller,),
-                  // TODO: recuperar dados do firestore
-                  SpendingSummaryWidget(
-                    spendingData: controller.sampleSpending,
-                  ),
+                  Obx(() {
+                    if (controller.spendingByCategory.isNotEmpty) {
+                      return SpendingSummaryWidget(
+                        title: 'Gastos por Categoria',
+                        spendingData: controller.spendingByCategory,
+                      );
+                    } else {
+                      return const SizedBox.shrink();
+                    }
+                  }),
+                  Obx(() {
+                    if (controller.incomeByCategory.isNotEmpty) {
+                      return SpendingSummaryWidget(
+                        title: 'Receitas por Categoria',
+                        spendingData: controller.incomeByCategory,
+                      );
+                    } else {
+                      return const SizedBox.shrink();
+                    }
+                  }),
                 ],
               ),
             ),

--- a/lib/modules/dashboard/widgets/spending_summary_widget.dart
+++ b/lib/modules/dashboard/widgets/spending_summary_widget.dart
@@ -7,9 +7,14 @@ import 'package:intl/intl.dart';
 
 
 class SpendingSummaryWidget extends StatelessWidget {
+  final String title;
   final Map<String, double> spendingData;
 
-  const SpendingSummaryWidget({super.key, required this.spendingData});
+  const SpendingSummaryWidget({
+    super.key,
+    required this.title,
+    required this.spendingData,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -50,7 +55,7 @@ class SpendingSummaryWidget extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           spacing: 16,
           children: [
-            Text('Gastos por Categoria', style: theme.textTheme.titleMedium),
+            Text(title, style: theme.textTheme.titleMedium),
             const Divider(),
             ...processedCategories.entries.map((entry) {
               final String category = entry.key;


### PR DESCRIPTION
Este commit introduz a funcionalidade de exibir os gastos e receitas agrupados por categoria na tela de Dashboard.

- **DashboardController:**
    - Adiciona `spendingByCategory` e `incomeByCategory` para armazenar os totais de gastos e receitas por categoria.
    - Modifica `_calculateSummaries` para calcular e agrupar as transações por categoria (método de pagamento).
    - Remove `sampleSpending` que continha dados mocados.

- **SpendingSummaryWidget:**
    - Adiciona um parâmetro `title` para permitir a reutilização do widget para exibir tanto gastos quanto receitas.
    - O título do widget agora é dinâmico.

- **DashboardScreen:**
    - Atualiza a tela para exibir dois `SpendingSummaryWidget`: um para "Gastos por Categoria" e outro para "Receitas por Categoria".
    - Os widgets de resumo de gastos e receitas por categoria são exibidos condicionalmente, aparecendo apenas se houver dados correspondentes.