### PR TITLE
refactor: Ajustes de texto e estilo na interface

### DIFF
--- a/lib/modules/auth/ui/auth_screen.dart
+++ b/lib/modules/auth/ui/auth_screen.dart
@@ -140,7 +140,7 @@ class AuthScreen extends GetView<AuthController> {
         Text('Não tem uma conta?'),
         TextButton(
           onPressed: () => Get.toNamed(Routes.CREATE_ACCOUNT),
-          child: const Text('Crie uma agora'),
+          child: const Text('Crie uma agora!'),
         ),
       ],
     );

--- a/lib/modules/create/ui/create_screen.dart
+++ b/lib/modules/create/ui/create_screen.dart
@@ -163,7 +163,7 @@ class CreateScreen extends GetView<CreateController> {
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         Text('Já tenho uma conta?'),
-        TextButton(onPressed: Get.back, child: const Text('Login')),
+        TextButton(onPressed: Get.back, child: const Text('Faça login')),
       ],
     );
   }

--- a/lib/modules/dashboard/widgets/category_summary_widget.dart
+++ b/lib/modules/dashboard/widgets/category_summary_widget.dart
@@ -25,7 +25,6 @@ class CategorySummaryWidget extends StatelessWidget {
       Colors.teal,
       Colors.redAccent,
       Colors.indigoAccent,
-      Colors.greenAccent,
     ];
 
     final currencyFormatter = NumberFormat.currency(
@@ -97,6 +96,7 @@ class CategorySummaryWidget extends StatelessWidget {
                 currencyFormatter.format(value),
                 style: theme.textTheme.bodyLarge?.copyWith(
                   fontWeight: FontWeight.bold,
+                  color: barColor,
                 ),
               ),
             ],

--- a/lib/modules/forget/ui/forget_screen.dart
+++ b/lib/modules/forget/ui/forget_screen.dart
@@ -113,7 +113,7 @@ class ForgotScreen extends GetView<ForgotController> {
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         Text('Lembrou sua senha?'),
-        TextButton(onPressed: Get.back, child: const Text('Login')),
+        TextButton(onPressed: Get.back, child: const Text('Faça login')),
       ],
     );
   }

--- a/lib/modules/home/widgets/transaction_form_sheet.dart
+++ b/lib/modules/home/widgets/transaction_form_sheet.dart
@@ -23,7 +23,7 @@ class TransactionFormSheet extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Text(
-              controller.isEditMode ? 'Editar Transação' : 'Nova Transação',
+              controller.isEditMode ? 'Editar transação' : 'Nova transação',
               style: theme.textTheme.headlineSmall,
             ),
             const SizedBox(height: 24),
@@ -47,14 +47,14 @@ class TransactionFormSheet extends StatelessWidget {
       () => SegmentedButton<TransactionType>(
         segments: const [
           ButtonSegment(
-            value: TransactionType.expense,
-            label: Text('Saída'),
-            icon: Icon(Icons.arrow_downward),
-          ),
-          ButtonSegment(
             value: TransactionType.income,
             label: Text('Entrada'),
             icon: Icon(Icons.arrow_upward),
+          ),
+          ButtonSegment(
+            value: TransactionType.expense,
+            label: Text('Saída'),
+            icon: Icon(Icons.arrow_downward),
           ),
         ],
         selected: {controller.selectedType.value},
@@ -117,7 +117,7 @@ class TransactionFormSheet extends StatelessWidget {
     return CustomTextField(
       controller: controller.descriptionController,
       labelText: 'Descrição',
-      hintText: 'Supermercado, aluguel...',
+      hintText: 'Descrição',
       prefixIcon: Icons.description_outlined,
       keyboardType: TextInputType.text,
       validator: (value) =>

--- a/lib/modules/transaction/controllers/transaction_controller.dart
+++ b/lib/modules/transaction/controllers/transaction_controller.dart
@@ -62,10 +62,10 @@ class TransactionController extends GetxController {
 
   void deleteTransaction(TransactionModel transaction) {
     AppDialogs.showConfirmationDialog(
-      title: 'Confirmar Exclusão',
+      title: 'Confirmar exclusão',
       message:
-          'Você tem certeza que deseja deletar esta transação? '
-          'Esta ação não pode ser desfeita.',
+          'Você tem certeza que deseja excluir esta transação? '
+          'Esta ação não poderá ser desfeita.',
       onConfirm: () async {
         try {
           await _databaseService.deleteTransaction(transaction);

--- a/lib/modules/transaction/widgets/transaction_options_sheet.dart
+++ b/lib/modules/transaction/widgets/transaction_options_sheet.dart
@@ -20,8 +20,8 @@ class TransactionOptionsSheet extends GetView<TransactionController> {
       child: Wrap(
         children: <Widget>[
           ListTile(
-            leading: Icon(Icons.edit, color: theme.colorScheme.onSurface),
-            title: Text('Editar Transação'),
+            leading: Icon(Icons.edit, color: theme.colorScheme.secondary),
+            title: Text('Editar transação'),
             onTap: () {
               Get.back();
               controller.editTransaction(transaction);
@@ -29,7 +29,7 @@ class TransactionOptionsSheet extends GetView<TransactionController> {
           ),
           ListTile(
             leading: Icon(Icons.delete, color: theme.colorScheme.error),
-            title: Text('Deletar Transação'),
+            title: Text('Deletar transação'),
             onTap: () {
               Get.back();
               controller.deleteTransaction(transaction);


### PR DESCRIPTION
Este commit realiza uma série de pequenos ajustes de texto (copywriting) e estilo em diversas partes da aplicação para melhorar a consistência e a experiência do usuário.

- **`transaction_controller.dart`**: Ajusta o texto do diálogo de confirmação de exclusão para usar minúsculas e melhorar a fluidez da frase.
- **`auth_screen.dart`**: Altera "Crie uma agora" para "Crie uma agora!" para ser mais convidativo.
- **`create_screen.dart` & `forget_screen.dart`**: Padroniza o texto do botão de "Login" para "Faça login".
- **`transaction_options_sheet.dart`**: Altera os títulos "Editar Transação" e "Deletar Transação" para "Editar transação" e "Deletar transação", e muda a cor do ícone de edição para a cor secundária do tema.
- **`category_summary_widget.dart`**:
    - Remove uma cor (greenAccent) da lista de cores para os gráficos.
    - Aplica a cor da barra correspondente ao valor monetário para melhor associação visual.
- **`transaction_form_sheet.dart`**:
    - Altera os títulos "Editar Transação" e "Nova Transação" para minúsculas.
    - Inverte a ordem dos botões de "Entrada" e "Saída".
    - Muda o `hintText` do campo de descrição de "Supermercado, aluguel..." para "Descrição".