### PR TITLE
style: Corrige a formatação de blocos de código no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ Siga os passos abaixo para configurar e rodar o projeto localmente.
 
 ### 1. Configuração do Projeto Local
 
-1. Clone este repositório:
-    ```bash  
-git clone https://github.com/carloscallejas91/bytebank_app.git ```
-2. Instale as dependências:
-    ```bash  
-flutter pub get ```
-3. Execute o aplicativo:
-    ```bash  
-flutter run ```
+1. Clone este repositório:  
+   ``  
+ git clone https://github.com/carloscallejas91/bytebank_app.git ``
+2. Instale as dependências:  
+   `` 
+ flutter pub get ``
+3. Execute o aplicativo:  
+   `` 
+ flutter run ``
 ## 📂 Estrutura de Pastas
 
 O projeto segue uma estrutura modular para manter o código organizado e desacoplado.


### PR DESCRIPTION
Este commit corrige a formatação dos blocos de comando na seção "Configuração do Projeto Local" do arquivo `README.md`. As tags `bash` foram removidas e a indentação ajustada para garantir a renderização correta dos snippets de código.