### PR TITLE
feat: Implementa paginação na lista de transações

### DIFF
--- a/lib/app/data/models/transaction_model.dart
+++ b/lib/app/data/models/transaction_model.dart
@@ -8,6 +8,7 @@ class TransactionModel {
   final String paymentMethod;
   final double amount;
   final DateTime date;
+  final DocumentSnapshot? snapshot;
 
   TransactionModel({
     required this.id,
@@ -16,6 +17,7 @@ class TransactionModel {
     required this.paymentMethod,
     required this.amount,
     required this.date,
+    this.snapshot,
   });
 
   Map<String, dynamic> toMap(String userId) {
@@ -40,6 +42,7 @@ class TransactionModel {
       paymentMethod: data['paymentMethod'] ?? '',
       amount: (data['amount'] as num).toDouble(),
       date: (data['date'] as Timestamp).toDate(),
+      snapshot: doc,
     );
   }
 }

--- a/lib/modules/home/controllers/transaction_form_controller.dart
+++ b/lib/modules/home/controllers/transaction_form_controller.dart
@@ -7,6 +7,8 @@ import 'package:mobile_app/app/services/database_service.dart';
 import 'package:mobile_app/app/services/snack_bar_service.dart';
 import 'package:uuid/uuid.dart';
 
+import '../../transaction/controllers/transaction_controller.dart';
+
 class TransactionFormController extends GetxController {
   // Services
   final _databaseService = Get.find<DatabaseService>();
@@ -145,6 +147,9 @@ class TransactionFormController extends GetxController {
   }
 
   void _handleSuccess({bool isUpdate = false}) {
+    final transactionListController = Get.find<TransactionController>();
+    transactionListController.refreshTransactions();
+
     if (isUpdate) {
       Get.back();
     } else {

--- a/lib/modules/transaction/ui/transaction_screen.dart
+++ b/lib/modules/transaction/ui/transaction_screen.dart
@@ -58,16 +58,34 @@ class TransactionScreen extends GetView<TransactionController> {
 
   Widget _buildTransactionList() {
     return Expanded(
-      child: ListView.separated(
-        itemCount: controller.transactions.length,
-        itemBuilder: (context, index) {
-          final transaction = controller.transactions[index];
-          return TransactionListItem(
-            transaction: transaction,
-            onTap: () => controller.showOptionsSheet(transaction),
-          );
-        },
-        separatorBuilder: (context, index) => const SizedBox(height: 8),
+      child: RefreshIndicator(
+        onRefresh: controller.refreshTransactions,
+        child: Obx(
+          () => ListView.separated(
+            controller: controller.scrollController,
+            itemCount:
+                controller.transactions.length +
+                (controller.hasMore.value ? 1 : 0),
+            itemBuilder: (context, index) {
+              if (index == controller.transactions.length) {
+                return controller.isLoadingMore.value
+                    ? const Center(
+                        child: Padding(
+                          padding: EdgeInsets.all(8.0),
+                          child: CircularProgressIndicator(),
+                        ),
+                      )
+                    : const SizedBox.shrink();
+              }
+              final transaction = controller.transactions[index];
+              return TransactionListItem(
+                transaction: transaction,
+                onTap: () => controller.showOptionsSheet(transaction),
+              );
+            },
+            separatorBuilder: (context, index) => const SizedBox(height: 8),
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
Este commit substitui o carregamento em tempo real (via `Stream`) por uma estratégia de paginação sob demanda na tela de transações, visando melhorar a performance e reduzir o consumo de dados.

Principais alterações:

- **`transaction_controller.dart`**:
    - Remove a escuta ao `Stream` do Firestore (`_listenToTransactionStream`).
    - Adiciona lógica de paginação, com funções para buscar a primeira (`fetchFirstPage`) e as próximas páginas (`fetchNextPage`).
    - Implementa um `ScrollController` para carregar mais transações automaticamente quando o usuário rola a lista até o final (`_scrollListener`).
    - Adiciona uma função `refreshTransactions` para recarregar a lista do início.

- **`database_service.dart`**:
    - Adiciona o método `fetchTransactionsPage` que busca um lote limitado de transações no Firestore, com suporte para `startAfter` para a paginação.
    - Remove o `Stream` de transações que não é mais utilizado.

- **`transaction_screen.dart`**:
    - Envolve a `ListView` com um `RefreshIndicator` para permitir a atualização manual da lista.
    - Adiciona um `CircularProgressIndicator` no final da lista para indicar o carregamento de mais itens.

- **`transaction_model.dart`**: Adiciona a propriedade `snapshot` para armazenar a referência do documento do Firestore, necessária para a paginação.

- **`transaction_form_controller.dart`**: Após a criação ou atualização de uma transação, chama `refreshTransactions` para garantir que a lista seja atualizada com os dados mais recentes.