### PR TITLE
feat: Implementa filtro e ordenação na lista de transações

### DIFF
--- a/lib/app/data/enums/sort_order.dart
+++ b/lib/app/data/enums/sort_order.dart
@@ -1,0 +1,1 @@
+enum SortOrder { asc, desc }

--- a/lib/app/data/models/paginated_transactions.dart
+++ b/lib/app/data/models/paginated_transactions.dart
@@ -1,0 +1,9 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:mobile_app/app/data/models/transaction_model.dart';
+
+class PaginatedTransactions {
+  final List<TransactionModel> transactions;
+  final DocumentSnapshot? lastDocument;
+
+  PaginatedTransactions({required this.transactions, this.lastDocument});
+}

--- a/lib/app/data/models/transaction_filter_model.dart
+++ b/lib/app/data/models/transaction_filter_model.dart
@@ -1,0 +1,10 @@
+import 'package:mobile_app/app/data/enums/transaction_type.dart';
+
+class TransactionFilter {
+  TransactionType? type;
+  String? paymentMethod;
+
+  TransactionFilter({this.type, this.paymentMethod});
+
+  bool get isEnabled => type != null || paymentMethod != null;
+}

--- a/lib/modules/dashboard/controllers/dashboard_controller.dart
+++ b/lib/modules/dashboard/controllers/dashboard_controller.dart
@@ -217,13 +217,9 @@ class DashboardController extends GetxController {
       final category = t.paymentMethod;
       if (t.type == TransactionType.income) {
         income += t.amount;
-
-        // Agrupa os totais de entrada por categoria
         incomeTotals[category] = (incomeTotals[category] ?? 0) + t.amount;
       } else {
         expenses += t.amount;
-
-        // Agrupa os totais de saída por categoria
         spendingTotals[category] = (spendingTotals[category] ?? 0) + t.amount;
       }
     }

--- a/lib/modules/transaction/ui/transaction_screen.dart
+++ b/lib/modules/transaction/ui/transaction_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:mobile_app/app/data/enums/sort_order.dart';
+import 'package:mobile_app/app/data/enums/transaction_type.dart';
 import 'package:mobile_app/modules/transaction/controllers/transaction_controller.dart';
 import 'package:mobile_app/modules/transaction/widgets/transaction_list_item.dart';
 
@@ -13,18 +15,14 @@ class TransactionScreen extends GetView<TransactionController> {
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 32.0),
-      child: Obx(() {
-        if (controller.transactions.isEmpty) {
-          return _buildEmptyState();
-        } else {
-          return _buildContent(theme);
-        }
-      }),
+      child: _buildContent(theme),
     );
   }
 
   Widget _buildEmptyState() {
-    return const Center(child: Text('Nenhuma transação encontrada.'));
+    return Expanded(
+      child: const Center(child: Text('Nenhuma transação encontrada.')),
+    );
   }
 
   Widget _buildContent(ThemeData theme) {
@@ -36,10 +34,17 @@ class TransactionScreen extends GetView<TransactionController> {
         padding: const EdgeInsets.all(16.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
+          spacing: 16,
           children: [
             _buildListHeader(theme),
-            const SizedBox(height: 16),
-            _buildTransactionList(),
+            _buildFilters(),
+            Obx(() {
+              if (controller.transactions.isEmpty) {
+                return _buildEmptyState();
+              } else {
+                return _buildTransactionList();
+              }
+            }),
           ],
         ),
       ),
@@ -50,9 +55,48 @@ class TransactionScreen extends GetView<TransactionController> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('Lista de Transações', style: theme.textTheme.titleMedium),
+        Row(
+          children: [
+            Text('Lista de Transações', style: theme.textTheme.titleMedium),
+            Obx(
+              () => IconButton(
+                icon: Icon(
+                  controller.sortOrder.value == SortOrder.desc
+                      ? Icons.arrow_downward
+                      : Icons.arrow_upward,
+                ),
+                tooltip: 'Alterar ordenação',
+                onPressed: controller.toggleSortOrder,
+              ),
+            ),
+          ],
+        ),
         const Divider(),
       ],
+    );
+  }
+
+  Widget _buildFilters() {
+    return Obx(
+      () => Wrap(
+        spacing: 8.0,
+        children: [
+          FilterChip(
+            label: const Text('Saídas'),
+            selected: controller.filter.value.type == TransactionType.expense,
+            onSelected: (selected) {
+              controller.toggleTypeFilter(TransactionType.expense);
+            },
+          ),
+          FilterChip(
+            label: const Text('Entradas'),
+            selected: controller.filter.value.type == TransactionType.income,
+            onSelected: (selected) {
+              controller.toggleTypeFilter(TransactionType.income);
+            },
+          ),
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
Este commit introduz a funcionalidade de filtrar transações por tipo (entrada/saída) e ordená-las por data (ascendente/descendente) na tela de transações.

- **`transaction_controller.dart`**:
    - Adiciona estado para gerenciar os filtros (`filter`) e a ordem de classificação (`sortOrder`).
    - Implementa as funções `toggleTypeFilter` e `toggleSortOrder` para atualizar a lista.
    - Modifica os métodos `fetchFirstPage` e `fetchNextPage` para passarem os parâmetros de filtro e ordenação ao `DatabaseService`.
    - A lista de transações é atualizada automaticamente ao deletar um item.

- **`transaction_screen.dart`**:
    - Adiciona `FilterChip` para permitir a seleção de filtros por tipo de transação (Entradas/Saídas).
    - Inclui um `IconButton` ao lado do título da lista para alternar a ordenação (ascendente/descendente).
    - Move o tratamento de "lista vazia" para dentro do `Obx`, garantindo que a tela responda corretamente aos filtros aplicados.

- **`database_service.dart`**:
    - O método `fetchTransactionsPage` agora aceita parâmetros de `filter` e `sortOrder` para construir queries dinâmicas no Firestore.
    - Retorna um objeto `PaginatedTransactions`, que encapsula a lista de transações e o `lastDocument` para paginação.

- **Novos modelos e enums**:
    - `TransactionFilter`: Novo modelo para conter os critérios de filtro.
    - `PaginatedTransactions`: Novo modelo para o retorno de dados paginados.
    - `SortOrder`: Enum (`asc`, `desc`) para definir a ordenação da consulta.