### PR TITLE
refator: Aprimora fluxo de criação de conta

### DIFF
--- a/lib/app/services/auth_service.dart
+++ b/lib/app/services/auth_service.dart
@@ -10,6 +10,9 @@ class AuthService extends GetxService {
   // User
   final user = Rxn<User>();
 
+  // Conditionals
+  bool isCreatingUser = false;
+
   //================================================================
   // Lifecycle Methods
   //================================================================
@@ -60,6 +63,8 @@ class AuthService extends GetxService {
   }) async {
     final DatabaseService databaseService = Get.find();
 
+    isCreatingUser = true;
+
     try {
       final userCredential = await _firebaseAuth.createUserWithEmailAndPassword(
         email: email.trim(),
@@ -76,8 +81,9 @@ class AuthService extends GetxService {
           name: name.trim(),
         );
 
-        await newUser.reload();
-        return _firebaseAuth.currentUser;
+        await _firebaseAuth.signOut();
+
+        return newUser;
       }
       return null;
     } on FirebaseAuthException {
@@ -87,6 +93,8 @@ class AuthService extends GetxService {
         "createUserWithEmailAndPassword: um erro inesperado ocorreu: $e",
       );
       rethrow;
+    } finally {
+      isCreatingUser = false;
     }
   }
 

--- a/lib/modules/auth/controllers/auth_controller.dart
+++ b/lib/modules/auth/controllers/auth_controller.dart
@@ -86,9 +86,9 @@ class AuthController extends GetxController {
   //================================================================
 
   void _handleAuthChanged(User? firebaseUser) {
-    if (firebaseUser != null) {
+    if (firebaseUser != null && !_authService.isCreatingUser) {
       Get.offAllNamed(Routes.HOME);
-    } else {
+    }  else if (firebaseUser == null) {
       Get.offAllNamed(Routes.AUTH);
     }
   }

--- a/lib/modules/create/controllers/create_controller.dart
+++ b/lib/modules/create/controllers/create_controller.dart
@@ -58,19 +58,20 @@ class CreateController extends GetxController {
       if (user != null) {
         _clearForm();
 
-        final bool documentReady = await _databaseService.waitForUserDocument(user.uid);
+        final bool documentReady = await _databaseService.waitForUserDocument(
+          user.uid,
+        );
 
         if (documentReady) {
           _snackBarService.showSuccess(
-            title: 'Bem-vindo(a), ${user.displayName}!',
-            message: 'Sua conta foi criada com sucesso.',
+            title: 'Sucesso!',
+            message:
+                'Sua conta foi criada com sucesso. Realize o '
+                'login para continuar.',
           );
-
-          Get.offAllNamed(Routes.HOME);
         } else {
           debugPrint('Falha ao inicializar os dados do usuário.');
         }
-
       }
     } on FirebaseAuthException catch (e) {
       debugPrint(e.message);


### PR DESCRIPTION
Este commit refatora o fluxo de criação de novas contas para melhorar a experiência do usuário e corrigir um redirecionamento automático indesejado.

- **`auth_service.dart`**:
    - Após a criação bem-sucedida do usuário, a sessão é agora finalizada com `signOut()`.
    - Um novo sinalizador `isCreatingUser` foi adicionado para evitar que o listener de autenticação (`_handleAuthChanged`) redirecione o usuário para a tela principal durante o processo de registro.

- **`auth_controller.dart`**:
    - O listener `_handleAuthChanged` foi ajustado para ignorar o redirecionamento para a tela `HOME` enquanto `isCreatingUser` for `true`, prevenindo que o usuário recém-criado seja logado automaticamente.

- **`create_controller.dart`**:
    - O redirecionamento automático para a `HOME` após o cadastro foi removido.
    - A mensagem de sucesso foi atualizada para instruir o usuário a realizar o login manualmente para continuar.