### PR TITLE
docs: Adiciona credenciais de teste e observações no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ Antes de começar, garanta que você tenha o seguinte instalado:
 > 2.  **Cole-o** dentro da pasta `android/app/` do projeto.
 >
 > Neste caso não é necessário realizar nenhuma configuração adicional do Firebase.
+>
+> **Usuário de Teste:**
+> -   **E-mail:** `avaliador@bytebank.com`
+> -   **Senha:** `Teste@01`
+>
+> **Observação:** Fique a vontade para criar uma conta caso queira.
+>
+> ---
+> **Observação sobre Recuperação de Senha:**
+> Ao testar a funcionalidade de "Recuperar Senha", o e-mail enviado pelo Firebase pode, por padrão, chegar na sua caixa de **Spam** ou **Lixo Eletrônico**. Por favor, verifique estas pastas caso não o encontre na sua caixa de entrada. Isso é um comportamento comum para e-mails automáticos enviados a partir de projetos em ambiente de desenvolvimento.
+
 
 ### 2. Opcional: Configuração do Firebase
 

--- a/lib/modules/dashboard/controllers/dashboard_controller.dart
+++ b/lib/modules/dashboard/controllers/dashboard_controller.dart
@@ -133,7 +133,11 @@ class DashboardController extends GetxController {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setString('user_avatar_path', savedImage.path);
 
-      userPhotoUrl.value = savedImage.path;
+      if (userPhotoUrl.value != savedImage.path) {
+        userPhotoUrl(savedImage.path);
+      } else {
+        userPhotoUrl.refresh();
+      }
 
       _snackBarService.showSuccess(
         title: 'Sucesso!',


### PR DESCRIPTION
Este commit adiciona informações importantes ao `README.md` para facilitar os testes da aplicação:
- Inclui um usuário de teste com e-mail e senha.
- Adiciona uma nota informando que o e-mail de recuperação de senha do Firebase pode ir para a caixa de Spam.

Adicionalmente, foi feito um pequeno ajuste no `dashboard_controller.dart` para garantir que a interface do usuário seja atualizada corretamente ao selecionar a mesma foto de perfil novamente.